### PR TITLE
Revert "chore(deps): update ghcr.io/siderolabs/tailscale docker tag to v1.60.0"

### DIFF
--- a/.github/workflows/talos-boot-assets.yaml
+++ b/.github/workflows/talos-boot-assets.yaml
@@ -19,7 +19,7 @@ env:
   # renovate: depName=ghcr.io/siderolabs/amdgpu-firmware
   AMDGPU_FIRMWARE_VERSION: 20231111
   # renovate: depName=ghcr.io/siderolabs/tailscale
-  TAILSCALE_VERSION: 1.60.0
+  TAILSCALE_VERSION: 1.56.1
 
 jobs:
   check-releases:


### PR DESCRIPTION
Reverts jtcressy-home/talos-boot-assets#6

Currently a bug where the extension for tailscale 1.60.0 appears to have talos 1.7.0 requirements.